### PR TITLE
Fix rest rendering and tests

### DIFF
--- a/frontend/components/MusicPart.vue
+++ b/frontend/components/MusicPart.vue
@@ -227,7 +227,7 @@ const drawScore = async () => {
       if (note.getCategory && note.getCategory() === 'barnotes') return;
       const noteData = allRenderedNotes[renderedIdx];
       renderedIdx += 1;
-      if (noteData && !noteData.rest && note.getBoundingBox) {
+      if (noteData && note.getBoundingBox) {
         const bbox = note.getBoundingBox();
         if (bbox) {
           renderedNotesInfo.value.push({

--- a/frontend/tests/MusicPart.spec.js
+++ b/frontend/tests/MusicPart.spec.js
@@ -116,6 +116,28 @@ describe('MusicPart.vue', () => {
 
     const emitted = wrapper.emitted()['update:part']?.[0]?.[0]
     expect(emitted).toBeTruthy()
-    expect(emitted.notesInput).toBe('D4/q, E4/q, B4/h')
+    expect(emitted.notesInput).toBe('D4/q, E4/q, B4/h/r')
+  })
+
+  it('uses a rest when filling empty measures', () => {
+    const wrapper = mount(MusicPart, { props: baseProps })
+    const measures = wrapper.vm.splitIntoMeasures([])
+    expect(measures[0][0].rest).toBe(true)
+  })
+
+  it('opens editor when clicking a rest', () => {
+    const wrapper = mount(MusicPart, {
+      props: { part: { name: 'Test Part', notesInput: 'B4/q/r' }, partIndex: 0 }
+    })
+    wrapper.vm.renderedNotesInfo = [{ noteIndex: 0, x: 0, y: 0, width: 20, height: 20 }]
+    const event = {
+      currentTarget: { getBoundingClientRect: () => ({ left: 0, top: 0 }) },
+      clientX: 10,
+      clientY: 10,
+      stopPropagation: vi.fn()
+    }
+    wrapper.vm.handleClickOnScore(event)
+    expect(wrapper.vm.noteMenuVisible).toBe(true)
+    expect(wrapper.vm.selectedNote.rest).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- track rest notes for editing
- update rest parsing tests and defaults
- ensure rest editing via click is possible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a7dbe15e08325942d34a8b146a743