### PR TITLE
Add JSON export utility for MusicPart

### DIFF
--- a/frontend/components/MusicPart.vue
+++ b/frontend/components/MusicPart.vue
@@ -30,6 +30,7 @@
         <label class="form-label small mb-1">Part Name</label>
         <input type="text" v-model="editablePartName" @input="updatePartName" class="form-control form-control-sm">
       </div>
+      <button class="btn btn-secondary btn-sm mb-2" @click="copyPartJson">Copy JSON</button>
       <button class="btn btn-danger btn-sm" @click="deletePart">Delete Part</button>
     </div>
 
@@ -324,6 +325,20 @@ const openPartMenu = (event) => {
 
 const updatePartName = () => {
   emit('update:part', { ...props.part, name: editablePartName.value });
+};
+
+const getPartJson = () => {
+  return JSON.stringify(toRaw(props.part), null, 2);
+};
+
+const copyPartJson = async () => {
+  try {
+    await navigator.clipboard.writeText(getPartJson());
+    alert('Part JSON copied to clipboard');
+  } catch (err) {
+    console.error('Failed to copy JSON:', err);
+    alert(getPartJson());
+  }
 };
 
 const deletePart = () => {

--- a/frontend/tests/MusicPart.spec.js
+++ b/frontend/tests/MusicPart.spec.js
@@ -147,4 +147,10 @@ describe('MusicPart.vue', () => {
     expect(notes[0].rest).toBe(true)
     expect(notes[1].rest).toBe(false)
   })
+
+  it('returns JSON string of part', () => {
+    const wrapper = mount(MusicPart, { props: baseProps })
+    const json = wrapper.vm.getPartJson()
+    expect(JSON.parse(json)).toEqual(baseProps.part)
+  })
 })


### PR DESCRIPTION
## Summary
- add button in part menu to copy JSON representation of a part
- implement `getPartJson` and `copyPartJson` methods
- test that JSON output works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a862dab748325898f509dabd5c331